### PR TITLE
Fix for newer saltstack versions

### DIFF
--- a/opendkim/init.sls
+++ b/opendkim/init.sls
@@ -6,7 +6,7 @@
 {% if 'lookup' in opendkim_settings and 'pkgs' in opendkim_settings.lookup %}
 opendkim:
   pkg.installed:
-    - pkgs: {{ opendkim_settings.lookup.pkgs }}
+    - pkgs: {{ opendkim_settings.lookup.pkgs | tojson }}
 {% endif %}
 
 {# EOF #}


### PR DESCRIPTION
See https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer